### PR TITLE
Disable base64EncodedSecret by default

### DIFF
--- a/00-Starter-Seed/src/main/resources/auth0.properties.example
+++ b/00-Starter-Seed/src/main/resources/auth0.properties.example
@@ -7,7 +7,7 @@ auth0.securedRoute: /portal/*
 auth0.loginCallback: /callback
 auth0.loginRedirectOnSuccess: /portal/home
 auth0.loginRedirectOnFail: /login
-auth0.base64EncodedSecret: true
+auth0.base64EncodedSecret: false
 auth0.authorityStrategy: ROLES
 auth0.defaultAuth0WebSecurityEnabled: false
 auth0.signingAlgorithm: HS256

--- a/01-Login/src/main/resources/auth0.properties.example
+++ b/01-Login/src/main/resources/auth0.properties.example
@@ -7,7 +7,7 @@ auth0.securedRoute: /portal/*
 auth0.loginCallback: /callback
 auth0.loginRedirectOnSuccess: /portal/home
 auth0.loginRedirectOnFail: /login
-auth0.base64EncodedSecret: true
+auth0.base64EncodedSecret: false
 auth0.authorityStrategy: ROLES
 auth0.defaultAuth0WebSecurityEnabled: false
 auth0.signingAlgorithm: HS256

--- a/02-Custom-Login/src/main/resources/auth0.properties.example
+++ b/02-Custom-Login/src/main/resources/auth0.properties.example
@@ -7,7 +7,7 @@ auth0.securedRoute: /portal/*
 auth0.loginCallback: /callback
 auth0.loginRedirectOnSuccess: /portal/home
 auth0.loginRedirectOnFail: /login
-auth0.base64EncodedSecret: true
+auth0.base64EncodedSecret: false
 auth0.authorityStrategy: ROLES
 auth0.defaultAuth0WebSecurityEnabled: false
 auth0.connection: {CONNECTION}

--- a/03-Spring-Session/src/main/resources/auth0.properties.example
+++ b/03-Spring-Session/src/main/resources/auth0.properties.example
@@ -7,7 +7,7 @@ auth0.securedRoute: /portal/*
 auth0.loginCallback: /callback
 auth0.loginRedirectOnSuccess: /portal/home
 auth0.loginRedirectOnFail: /login
-auth0.base64EncodedSecret: true
+auth0.base64EncodedSecret: false
 auth0.authorityStrategy: ROLES
 auth0.defaultAuth0WebSecurityEnabled: false
 auth0.signingAlgorithm: HS256

--- a/06-Rules/src/main/resources/auth0.properties.example
+++ b/06-Rules/src/main/resources/auth0.properties.example
@@ -7,7 +7,7 @@ auth0.securedRoute: /portal/*
 auth0.loginCallback: /callback
 auth0.loginRedirectOnSuccess: /portal/home
 auth0.loginRedirectOnFail: /login
-auth0.base64EncodedSecret: true
+auth0.base64EncodedSecret: false
 auth0.authorityStrategy: ROLES
 auth0.defaultAuth0WebSecurityEnabled: false
 auth0.connection: {CONNECTION}


### PR DESCRIPTION
Only merge this PR when Auth0 officially switches to client secrets that are not base64 encoded.
